### PR TITLE
Fix licenses for src/qttableview.*

### DIFF
--- a/src/qttableview.cpp
+++ b/src/qttableview.cpp
@@ -1,10 +1,35 @@
 /**********************************************************************
 ** $Id: qttableview.cpp,v 1.115 2011/08/27 00:13:41 fasthyun Exp $
 ** Implementation of QtTableView class
-** Created : 941115
+**
 ** Copyright (C) 1992-2000 Trolltech AS.  All rights reserved.
-** This file contains a class moved out of the Qt GUI Toolkit API. It
-** may be used, distributed and modified without limitation.
+**
+** This file contains a class moved out of the Qt GUI Toolkit API.
+**
+** This file may be distributed under the terms of the Q Public License
+** as defined by Trolltech AS of Norway and appearing in the file
+** LICENSE.QPL included in the packaging of this file.
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU General Public License version 2 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** Licensees holding valid Qt Enterprise Edition or Qt Professional Edition
+** licenses may use this file in accordance with the Qt Commercial License
+** Agreement provided with the Software.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** See http://www.trolltech.com/pricing.html or email sales@trolltech.com for
+**   information about Qt Commercial License Agreements.
+** See http://www.trolltech.com/qpl/ for QPL licensing information.
+** See http://www.trolltech.com/gpl/ for GPL licensing information.
+**
+** Contact info@trolltech.com if any conditions of this licensing are
+** not clear to you.
+**
 **********************************************************************/
 
 #include "qttableview.h"

--- a/src/qttableview.h
+++ b/src/qttableview.h
@@ -7,8 +7,31 @@
 **
 ** Copyright (C) 1992-2000 Trolltech AS.  All rights reserved.
 **
-** This file contains a class moved out of the Qt GUI Toolkit API. It
-** may be used, distributed and modified without limitation.
+** This file contains a class moved out of the Qt GUI Toolkit API.
+**
+** This file may be distributed under the terms of the Q Public License
+** as defined by Trolltech AS of Norway and appearing in the file
+** LICENSE.QPL included in the packaging of this file.
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU General Public License version 2 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** Licensees holding valid Qt Enterprise Edition or Qt Professional Edition
+** licenses may use this file in accordance with the Qt Commercial License
+** Agreement provided with the Software.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** See http://www.trolltech.com/pricing.html or email sales@trolltech.com for
+**   information about Qt Commercial License Agreements.
+** See http://www.trolltech.com/qpl/ for QPL licensing information.
+** See http://www.trolltech.com/gpl/ for GPL licensing information.
+**
+** Contact info@trolltech.com if any conditions of this licensing are
+** not clear to you.
 **
 **********************************************************************/
 


### PR DESCRIPTION
One can not rip out parts of licensed software, mention the copyright holder
and say: It was $foo, copyright holder was $bar. But i ripped this out, you
are free to do with this what you want and without limitation - this will not
work that way.

So the copied parts remain under both QPL-1.0 and GPL2. The added code inherit
the original licenses as not stated otherwise.